### PR TITLE
solve styling/char-esacping issues in current code of conduct 

### DIFF
--- a/src/pages/coc.re
+++ b/src/pages/coc.re
@@ -1,6 +1,7 @@
 let component = ReasonReact.statelessComponent("CodeOfConduct");
 
 let ste = ReasonReact.stringToElement;
+let ate = ReasonReact.arrayToElement;
 
 let make = (_children) => {
   ...component,
@@ -15,13 +16,15 @@ let make = (_children) => {
         )
       </p>
       <h2> (ste("Need Help?")) </h2>
-      <p> (ste("You have our contact details in the emails we&#39;ve sent.")) </p>
+      <p> (ste("You have our contact details in the emails we've sent.")) </p>
       <h2> (ste("The Quick Version")) </h2>
       <p>
         (
-          ste(
-            "Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers."
-          )
+          ate([|
+            (ste("Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference ")),
+            <em>(ste("without a refund"))</em>,
+            (ste(" at the discretion of the conference organisers.")),
+          |])
         )
       </p>
       <h2> (ste("The Less Quick Version")) </h2>
@@ -56,7 +59,7 @@ let make = (_children) => {
       <p>
         (
           ste(
-            "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded clothing and/or badges."
+            "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges."
           )
         )
       </p>

--- a/src/pages/coc.re
+++ b/src/pages/coc.re
@@ -16,7 +16,7 @@ let make = (_children) => {
         )
       </p>
       <h2> (ste("Need Help?")) </h2>
-      <p> (ste("You have our contact details in the emails we've sent.")) </p>
+      <p> (ste("You have our contact details in the emails we’ve sent.")) </p>
       <h2> (ste("The Quick Version")) </h2>
       <p>
         (
@@ -59,7 +59,7 @@ let make = (_children) => {
       <p>
         (
           ste(
-            "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges."
+            "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they’ll be wearing branded clothing and/or badges."
           )
         )
       </p>


### PR DESCRIPTION
tried to fix some char-escaping issues that pop up in the current coc implementation.

don't know whether that's the proper reason way to fix this. it works locally.