### PR TITLE
Use bsrefmt for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "puppeteer": "^1.2.0"
   },
   "lint-staged": {
-    "*.re": ["refmt --in-place", "git add"],
+    "*.re": ["bsrefmt --in-place", "git add"],
     "*.{js,json,md,css,scss}": ["prettier --write", "git add"]
   },
   "browserslist": ["> 1%", "last 2 versions", "IE 11"]


### PR DESCRIPTION
There were problems when old `reason-cli` packages with older `refmt` versions are not compatible with the locally installed `refmt` used by `bs-platform`... this will make sure lint-staged always uses the `bsrefmt` version