### PR TITLE
Print social links in speaker’s cards

### DIFF
--- a/src/components/socialLink.module.scss
+++ b/src/components/socialLink.module.scss
@@ -1,5 +1,16 @@
 .item {
-  margin-right: 0.6em;
+  max-width: 18px;
+  max-height: 18px;
+  margin-right: 5px;
+  background-image: none;
+
+  &:hover {
+    background-image: none;
+
+    g:last-child {
+      fill: #dd4b39 !important;
+    }
+  }
 
   &:last-child {
     margin-right: 0;

--- a/src/components/socialLink.module.scss
+++ b/src/components/socialLink.module.scss
@@ -1,0 +1,18 @@
+.item {
+  margin-bottom: 0.1em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.link {
+  position: relative;
+  margin-left: 1.25em;
+
+  i {
+    position: absolute;
+    left: -1.25em;
+    top: 0.22em;
+  }
+}

--- a/src/components/socialLink.module.scss
+++ b/src/components/socialLink.module.scss
@@ -1,8 +1,8 @@
 .item {
-  margin-bottom: 0.1em;
+  margin-right: 0.6em;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-right: 0;
   }
 }
 

--- a/src/components/socialLink.re
+++ b/src/components/socialLink.re
@@ -1,0 +1,31 @@
+open Util;
+
+[@bs.module] external style : Js.t({..}) = "./socialLink.module.scss";
+
+type target =
+  | Twitter
+  | Github
+  | Website;
+
+let component = ReasonReact.statelessComponent("SocialLink");
+
+let make = (~target: target, ~link: option(string), _children) => {
+  ...component,
+  render: _self =>
+    switch (link) {
+    | None => ReasonReact.null
+    | Some(link) =>
+      let (url, iconClass) =
+        switch (target) {
+        | Twitter => ("https://twitter.com/" ++ link, "fab fa-twitter")
+        | Github => ("https://github.com/" ++ link, "fab fa-github")
+        | Website => ("https://twitter.com/", "fas fa-globe")
+        };
+      <div className=style##item>
+        <a className=style##link href=url>
+          <i className=iconClass />
+          (link |> s)
+        </a>
+      </div>;
+    },
+};

--- a/src/components/socialLink.re
+++ b/src/components/socialLink.re
@@ -1,4 +1,4 @@
-open Util;
+open Gatsby;
 
 [@bs.module] external style : Js.t({..}) = "./socialLink.module.scss";
 
@@ -15,17 +15,12 @@ let make = (~target: target, ~link: option(string), _children) => {
     switch (link) {
     | None => ReasonReact.null
     | Some(link) =>
-      let (url, iconClass) =
+      let (url, network) =
         switch (target) {
-        | Twitter => ("https://twitter.com/" ++ link, "fab fa-twitter")
-        | Github => ("https://github.com/" ++ link, "fab fa-github")
-        | Website => ("https://twitter.com/", "fas fa-globe")
+        | Twitter => ("https://twitter.com/" ++ link, "twitter")
+        | Github => ("https://github.com/" ++ link, "github")
+        | Website => ("https://twitter.com/", "sharethis")
         };
-      <div className=style##item>
-        <a className=style##link href=url>
-          <i className=iconClass />
-          (link |> s)
-        </a>
-      </div>;
+      <SocialIcon className=style##item network url color="#9eb3bd" />;
     },
 };

--- a/src/components/speakerDetails.module.scss
+++ b/src/components/speakerDetails.module.scss
@@ -39,3 +39,7 @@
   margin: 0;
   color: $secondaryTextColor;
 }
+
+.social {
+  margin-top: 1em;
+}

--- a/src/components/speakerDetails.module.scss
+++ b/src/components/speakerDetails.module.scss
@@ -41,5 +41,8 @@
 }
 
 .social {
-  display: flex;
+  display: inline-flex;
+  vertical-align: middle;
+  margin-left: 3px;
+  margin-top: -2px;
 }

--- a/src/components/speakerDetails.module.scss
+++ b/src/components/speakerDetails.module.scss
@@ -41,5 +41,5 @@
 }
 
 .social {
-  margin-top: 1em;
+  display: flex;
 }

--- a/src/components/speakerDetails.re
+++ b/src/components/speakerDetails.re
@@ -15,12 +15,14 @@ let make = (~speaker: Data.Speaker.t, _children) => {
       <section className=style##speakerCard> <SpeakerCard speaker /> </section>
       <section className=style##description>
         <h2 className=style##name> (speaker.name |> s) </h2>
-        <div className=style##social>
-          <SocialLink target=Twitter link=speaker.social.twitterUser />
-          <SocialLink target=Github link=speaker.social.githubUser />
-          <SocialLink target=Website link=speaker.social.website />
-        </div>
-        <p className=style##company> (speaker.company |> s) </p>
+        <p className=style##company>
+          (speaker.company ++ ", " |> s)
+          <div className=style##social>
+            <SocialLink target=Twitter link=speaker.social.twitterUser />
+            <SocialLink target=Github link=speaker.social.githubUser />
+            <SocialLink target=Website link=speaker.social.website />
+          </div>
+        </p>
         (speaker.description |> md)
         (
           switch (speaker.talk) {

--- a/src/components/speakerDetails.re
+++ b/src/components/speakerDetails.re
@@ -15,6 +15,11 @@ let make = (~speaker: Data.Speaker.t, _children) => {
       <section className=style##speakerCard> <SpeakerCard speaker /> </section>
       <section className=style##description>
         <h2 className=style##name> (speaker.name |> s) </h2>
+        <div className=style##social>
+          <SocialLink target=Twitter link=speaker.social.twitterUser />
+          <SocialLink target=Github link=speaker.social.githubUser />
+          <SocialLink target=Website link=speaker.social.website />
+        </div>
         <p className=style##company> (speaker.company |> s) </p>
         (speaker.description |> md)
         (
@@ -27,11 +32,6 @@ let make = (~speaker: Data.Speaker.t, _children) => {
           | None => ReasonReact.null
           }
         )
-        <div className=style##social>
-          <SocialLink target=Twitter link=speaker.social.twitterUser />
-          <SocialLink target=Github link=speaker.social.githubUser />
-          <SocialLink target=Website link=speaker.social.website />
-        </div>
       </section>
     </section>,
 };

--- a/src/components/speakerDetails.re
+++ b/src/components/speakerDetails.re
@@ -27,6 +27,11 @@ let make = (~speaker: Data.Speaker.t, _children) => {
           | None => ReasonReact.null
           }
         )
+        <div className=style##social>
+          <SocialLink target=Twitter link=speaker.social.twitterUser />
+          <SocialLink target=Github link=speaker.social.githubUser />
+          <SocialLink target=Website link=speaker.social.website />
+        </div>
       </section>
     </section>,
 };

--- a/src/layouts/layoutIndex.re
+++ b/src/layouts/layoutIndex.re
@@ -71,14 +71,6 @@ let make = (~location, children) => {
       </div>
     | Normal =>
       <div className="page">
-        <Helmet title>
-          <link
-            rel="stylesheet"
-            href="https://use.fontawesome.com/releases/v5.0.13/css/all.css"
-            integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp"
-            crossorigin=true
-          />
-        </Helmet>
         <div className="container container_centered">
           <header> <Navigation pathName=location##pathname /> </header>
           <article> (children()) </article>

--- a/src/layouts/layoutIndex.re
+++ b/src/layouts/layoutIndex.re
@@ -71,6 +71,7 @@ let make = (~location, children) => {
       </div>
     | Normal =>
       <div className="page">
+        <Helmet title />
         <div className="container container_centered">
           <header> <Navigation pathName=location##pathname /> </header>
           <article> (children()) </article>

--- a/src/layouts/layoutIndex.re
+++ b/src/layouts/layoutIndex.re
@@ -71,7 +71,14 @@ let make = (~location, children) => {
       </div>
     | Normal =>
       <div className="page">
-        <Helmet title />
+        <Helmet title>
+          <link
+            rel="stylesheet"
+            href="https://use.fontawesome.com/releases/v5.0.13/css/all.css"
+            integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp"
+            crossorigin=true
+          />
+        </Helmet>
         <div className="container container_centered">
           <header> <Navigation pathName=location##pathname /> </header>
           <article> (children()) </article>


### PR DESCRIPTION
Hey!

During and after the conference, I wanted to look up speakers’ twitter/github links but there was no such info. This pull request fixes that problem. 

If you have some comments regarding styles I would gladly make changes in this PR. Also, I did use Font Awesome for social icons for the sake of speed. If it is not optimal, I'll include svg-icons to the build.

Result looks like this:
<img width="799" alt="screen shot 2018-05-15 at 15 37 34" src="https://user-images.githubusercontent.com/1197026/40057396-e061541c-5856-11e8-981e-41d326539869.png">
